### PR TITLE
Fix __vmi_class offsets

### DIFF
--- a/import_df_structures.java
+++ b/import_df_structures.java
@@ -308,6 +308,7 @@ public class import_df_structures extends GhidraScript {
 			baseClassTypeInfo = (Structure) createDataType(dtcABI, baseClassTypeInfo);
 
 			this.vmiClassTypeInfo = new StructureDataType("__vmi_class_type_info", 0);
+			this.vmiClassTypeInfo.setToDefaultAlignment();
 			this.vmiClassTypeInfo.add(typeInfo, "_super", null);
 			this.vmiClassTypeInfo.add(dtUint32, "__flags", null);
 			this.vmiClassTypeInfo.add(dtUint32, "__base_count", null);


### PR DESCRIPTION
The alignment wasn't set properly when creating the vmi class struct, and caused errors on Linux x64.


Also of note:
My copy of ghidra doesn't recognize the `Demangled` class referenced in this script. I must change it to `DemangledType` before it will compile. I'm not yet clear on what versions of ghidra use `Demangled` vs. `DemangledType`, so I haven't included it in this pr. Does anyone know what versions of ghidra run the script as-is?