### PR TITLE
ghidra importer: handle `original-name` correctly

### DIFF
--- a/ghidra/import_df_structures.java
+++ b/ghidra/import_df_structures.java
@@ -1064,7 +1064,8 @@ public class import_df_structures extends GhidraScript {
 							// ignore
 							break;
 						case "original-name":
-							((IOwnsType) stack.peek()).getOwnedType().originalName = reader.getAttributeValue(i);
+							if (stack.peek() instanceof TypeDef)
+								((IOwnsType) stack.peek()).getOwnedType().originalName = reader.getAttributeValue(i);
 							break;
 						case "is-union":
 							((IOwnsType) stack.peek()).getOwnedType().isUnion = Boolean


### PR DESCRIPTION
the importer was not handling the new `original-name` attributes on globals correctly

i told it to only apply `original-name` attributes in in the context of a type definition, which means they'll be ignored on globals

see also dfhack/df-structures#641