### PR TITLE
Fix import DF structures scripts on Linux

### DIFF
--- a/ghidra/import_df_structures.java
+++ b/ghidra/import_df_structures.java
@@ -1506,7 +1506,7 @@ public class import_df_structures extends GhidraScript {
 			case "stl-shared-ptr":
 				return createSharedPtrType(f.item == null ? null : getDataType(f.item));
 			case "stl-weak-ptr":
-				return createSharedPtrType(f.item == null ? null : getDataType(f.item));
+				return createWeakPtrType(f.item == null ? null : getDataType(f.item));
 			case "stl-function":
 				return createFunctionType(f.item == null ? null : getDataType(f.item));
 			case "stl-set":

--- a/ghidra/import_df_structures.java
+++ b/ghidra/import_df_structures.java
@@ -2477,6 +2477,15 @@ public class import_df_structures extends GhidraScript {
 
 	private void findLibrary(List<String> locations, String name, DomainFolder folder) {
 		var file = folder.getFile(name);
+		if (file == null) {
+			var files = folder.getFiles();
+			for (var f : files) {
+				if (f.getName().equalsIgnoreCase(name)) {
+					file = f;
+					break;
+				}
+			}
+		}
 		if (file != null) {
 			var md = file.getMetadata();
 			if (md.get("Executable Format").equals(currentProgram.getExecutableFormat())


### PR DESCRIPTION
* call `createWeakPtrType()` for `<stl-weak-ptr />`
* case-insensitive find libraries, useful to attach Windows DLLs on a case-sensitive filesystem
