### PR TITLE
Fix enum size overrides in Ghidra

### DIFF
--- a/ghidra/import_df_structures.java
+++ b/ghidra/import_df_structures.java
@@ -1498,13 +1498,13 @@ public class import_df_structures extends GhidraScript {
 		if (size != 0) {
 			name += "(" + (size * 8) + "-bit)";
 		}
-		if (createdTypes.contains(t.getName()) ) {
-			var existing = dtcEnums.getDataType(t.getName());
+		if (createdTypes.contains(name) ) {
+			var existing = dtcEnums.getDataType(name);
 			if (existing != null)
 				return existing;
 		}
 
-		createdTypes.add(t.getName());
+		createdTypes.add(name);
 
 		if (size == 0) {
 			if (t.baseType == null || t.baseType.isEmpty()) {


### PR DESCRIPTION
Mentioned in Discord - should fix the problems with incorrectly-sized `screw_pump_direction` fields (+ potentially other problems).