### PR TITLE
make importer work slightly better on linux

### DIFF
--- a/ghidra/import_df_structures.java
+++ b/ghidra/import_df_structures.java
@@ -2385,8 +2385,8 @@ public class import_df_structures extends GhidraScript {
 					&& ns.getParentNamespace().getSymbol().getSymbolType() == SymbolType.LIBRARY) {
 				println(ns.getName());
 			}
-			sym.setNamespace(ns);
 			try {
+				sym.setNamespace(ns);
 				if (sym.getName().equals("basic_string")) {
 					sym.setName("string", SourceType.IMPORTED);
 				} else if (sym.getName().equals("~basic_string")) {


### PR DESCRIPTION
move `setNamespace` inside `try` block since this can result in a duplicate name exception